### PR TITLE
Update git link in project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🎨 EzQt Widgets
 
-[![Repository](https://img.shields.io/badge/Repository-GitHub-blue?style=for-the-badge&logo=github)](https://github.com/neuraaak/ezqt_widgets)
+[![Repository](https://img.shields.io/badge/Repository-GitHub-blue?style=for-the-badge&logo=github)](https://github.com/neuraaak/EzQt-Widgets)
 [![PyPI](https://img.shields.io/badge/PyPI-ezqt_widgets-green?style=for-the-badge&logo=pypi)](https://pypi.org/project/EzQt-Widgets/)
-[![Tests](https://img.shields.io/badge/Tests-254%2F262%20passing-green?style=for-the-badge&logo=pytest)](https://github.com/neuraaak/ezqt_widgets/actions)
+[![Tests](https://img.shields.io/badge/Tests-254%2F262%20passing-green?style=for-the-badge&logo=pytest)](https://github.com/neuraaak/EzQt-Widgets/actions)
 
 A collection of custom and reusable Qt widgets for PySide6, designed to simplify the development of modern and intuitive graphical interfaces.
 
@@ -134,7 +134,7 @@ ezqt_widgets/
 
 ### **Development Installation**
 ```bash
-git clone https://github.com/your-username/ezqt_widgets.git
+git clone https://github.com/neuraaak/EzQt-Widgets.git
 cd ezqt_widgets
 pip install -e ".[dev]"
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update GitHub repository links in `README.md` to correct casing inconsistency.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous links in `README.md` used `ezqt_widgets` which did not match the actual repository URL `EzQt-Widgets` found in `.git/config`. This PR ensures all links point to the correct repository URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc9a4cc3-6765-4a63-818a-469ae767801f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc9a4cc3-6765-4a63-818a-469ae767801f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>